### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 ; vi:syntax=ini
-; See https://coverage.readthedocs.org/en/coverage-4.0.3/config.html
+; See https://coverage.readthedocs.io/en/coverage-4.0.3/config.html
 
 [run]
 data_file = .coverage

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ json_config
     :alt: Coverage Status
 
 .. image:: https://readthedocs.org/projects/json_config/badge/?version=develop
-    :target: https://json_config.readthedocs.org/en/develop/?badge=develop
+    :target: https://json_config.readthedocs.io/en/develop/?badge=develop
     :alt: Documentation Status
 
 
@@ -57,7 +57,7 @@ A convenience utility for working with JSON config files.
 Features
 --------
 
-- Documentation: https://json_config.readthedocs.org
+- Documentation: https://json_config.readthedocs.io
 - Open Source: https://github.com/bionikspoon/json_config
 - MIT license
 

--- a/docs/source/_partial/readme_features.rst
+++ b/docs/source/_partial/readme_features.rst
@@ -1,7 +1,7 @@
 Features
 --------
 
-- Documentation: https://json_config.readthedocs.org
+- Documentation: https://json_config.readthedocs.io
 - Open Source: https://github.com/bionikspoon/json_config
 - MIT license
 

--- a/docs/source/_partial/readme_title.rst
+++ b/docs/source/_partial/readme_title.rst
@@ -19,7 +19,7 @@ json_config
     :alt: Coverage Status
 
 .. image:: https://readthedocs.org/projects/json_config/badge/?version=develop
-    :target: https://json_config.readthedocs.org/en/develop/?badge=develop
+    :target: https://json_config.readthedocs.io/en/develop/?badge=develop
     :alt: Documentation Status
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-"""The full documentation is at https://json_config.readthedocs.org."""
+"""The full documentation is at https://json_config.readthedocs.io."""
 
 try:
     from setuptools import setup


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
